### PR TITLE
Fix argv out-of-bounds access

### DIFF
--- a/md5_test.c
+++ b/md5_test.c
@@ -5,7 +5,7 @@
 
 int main(int argc, char **argv)
 {
-    char *msg = argv[1];
+    char *msg;
     size_t len;
     int i;
     uint8_t result[16];
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
         printf("usage: %s 'string'\n", argv[0]);
         return 1;
     }
-
+    msg =  argv[1];
     len = strlen(msg);
 
     // benchmark


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md):

```
Spatial memory safety error (tried to access object [&(string with length 12: [md5_test.bc])] of class SEStaticAddressArray at byte offset 8 with length 8)
```

The error is caused when passing no arguments, in which case `argv` is accessed before checking that the access is in-bounds.